### PR TITLE
fix: on-chain upgrade name 3.0.0 -> v3.0.0 (match v2.x naming standard)

### DIFF
--- a/app/upgrades/v3.0.0/upgrade.go
+++ b/app/upgrades/v3.0.0/upgrade.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Name is the on-chain upgrade name for the Cosmos SDK v0.45 -> v0.47 migration.
-const Name = "3.0.0"
+const Name = "v3.0.0"
 
 // Upgrade migrates passage-2 from cosmos-sdk v0.45 (wasmd 0.34 / wasmvm 1.5.7) to
 // cosmos-sdk v0.47 (wasmd 0.45 / wasmvm 1.5.x). wasmvm stays in the 1.5 line so
@@ -61,7 +61,7 @@ func CreateUpgradeHandler(
 	paramsKeeper paramskeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		ctx.Logger().Info("3.0.0 upgrade: migrating Tendermint consensus params x/params -> x/consensus")
+		ctx.Logger().Info("v3.0.0 upgrade: migrating Tendermint consensus params x/params -> x/consensus")
 
 		// The "baseapp" subspace is not registered by initParamsKeeper, so a fresh
 		// Subspace call is safe here (it would panic if already occupied).
@@ -70,13 +70,13 @@ func CreateUpgradeHandler(
 			WithKeyTable(paramstypes.ConsensusParamsKeyTable())
 		baseapp.MigrateParams(ctx, legacyBaseAppSubspace, &consensusParamsKeeper)
 
-		ctx.Logger().Info("3.0.0 upgrade: running module migrations")
+		ctx.Logger().Info("v3.0.0 upgrade: running module migrations")
 		vm, err := mm.RunMigrations(ctx, configurator, fromVM)
 		if err != nil {
 			return nil, err
 		}
 
-		ctx.Logger().Info("3.0.0 upgrade: complete")
+		ctx.Logger().Info("v3.0.0 upgrade: complete")
 		return vm, nil
 	}
 }


### PR DESCRIPTION
﻿## On-chain upgrade name: `3.0.0` → `v3.0.0`

Every prior on-chain upgrade name on `passage-2` carries the `v` prefix — the handler `Name` constants are `v2.2.0`, `v2.4.0`, `v2.5.0`, `v2.6.0`. The `3.0.0` handler shipped without it. This one-line fix restores the convention so the upgrade name is **`v3.0.0`**.

```
app/upgrades/v3.0.0/upgrade.go:  const Name = "3.0.0"  ->  const Name = "v3.0.0"
```
(Log strings updated too; the directory/package were already `v3.0.0`/`v3_0_0`.)

### Validated
Re-ran the real-state fork test on an exported `passage-2` snapshot with the `v3.0.0` name: gov prop `v3.0.0` → halt at the upgrade height → handler `v3.0.0` fires → all module migrations → `v3.0.0 upgrade: complete`, blocks produced past the height, no panics.

### Heads-up — this changes the binary, so it needs a re-release
The on-chain name is baked into the binary's handler **and** must match the gov proposal. The current `v3.0.0` release binary has handler name `3.0.0`. After this merges, please **re-cut the `v3.0.0` release** (the existing one is hours old and not yet deployed by any validator) so the tag, the on-chain name, and the upgrade doc all read `v3.0.0`. The new gov proposal will use name `v3.0.0` and point `--upgrade-info` at the re-cut binary.

(The already-submitted proposal #21 used the old name `3.0.0`; it can't be cancelled on SDK 0.45, so it will be left to fail on quorum — deposit returns — and superseded by the corrected `v3.0.0` proposal.)
