### PR TITLE
fix: restore state queries broken by v3.0.0 (query-only, non-consensus)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,3 +216,5 @@ replace (
 )
 
 replace golang.org/x/exp => golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb
+
+replace github.com/cosmos/cosmos-sdk => github.com/Ninjaxan/cosmos-sdk v0.47.14-0.20260629142107-dcbf41b38356

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwS
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Ninjaxan/cosmos-sdk v0.47.14-0.20260629142107-dcbf41b38356 h1:5K6h4bjqiAkBBk6LCq6YnaDFIGRsNz/Pj0DapRAm5AQ=
+github.com/Ninjaxan/cosmos-sdk v0.47.14-0.20260629142107-dcbf41b38356/go.mod h1:pYMzhTfKFn9AJB5X64Epwe9NgYk0y3v7XN8Ks5xqWoo=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -384,8 +386,6 @@ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
 github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.47.13 h1:9d57rl2ilSgc8a6u1JAulqNX/E5w8lbqbRe3NON3Jb4=
-github.com/cosmos/cosmos-sdk v0.47.13/go.mod h1:pYMzhTfKFn9AJB5X64Epwe9NgYk0y3v7XN8Ks5xqWoo=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=


### PR DESCRIPTION
Since v3.0.0, **all state queries fail chain-wide** — LCD/REST, gRPC, and RPC `abci_query` — with `code 18: failed to load state at height H; version does not exist`. Wallets, explorers, and anything reading state are broken on every node. **Consensus is unaffected** (blocks produce, validators sign).

## Root cause
v3.0.0 added the `consensus` + `crisis` store keys. Post-upgrade, IAVL versioned-snapshot reads (`GetImmutable`) are broken for every version, while the *live* store consensus uses each block works fine. Every query routes through `CreateQueryContext → CacheMultiStoreWithVersion(height)` → hits the broken path. (Same class as cosmos-sdk #13477 / #21087; the upstream fix lives in iavl v1.x / SDK 0.50.)

## The fix — query-path only, NOT consensus-breaking
This points `cosmos-sdk` at a query-only patched fork (`github.com/Ninjaxan/cosmos-sdk@v0.47.13-passage-queryfix`): `baseapp.CreateQueryContext` serves **latest-height** queries from the live store (`qms.CacheMultiStore()`) instead of the broken versioned path; historical-height queries gracefully fall back.

Because the query path never touches block execution or the app-hash, a patched node produces **identical app-hashes** and stays in consensus with unpatched nodes — so validators can **swap the binary and restart, rolling, with no governance vote.**

This PR is just the `go.mod` replace + `go.sum`.

## Proven
Built as v3.0.1 (this branch) and deployed on the **CryptoDungeon** validator (rank ~#9): balance/staking queries return real data again, and the validator keeps **signing on mainnet** with identical app-hashes (fork-free). Binary + checksum: https://github.com/Ninjaxan/Passage3D/releases/tag/v3.0.1-querypatch (sha256 `a45959d26f1aa6199981fc9b1d005a21a5ed64c8d7b9af4fba4438e35da61954`).

## Suggested rollout
Tag an official **v3.0.1** from `v3.0.x`; validators + RPC/LCD providers swap the binary (rolling, no vote) and reads return chain-wide. Happy to help coordinate. The durable root-cause fix is the SDK 0.50 upgrade (separate, planned).

— Crypto Dungeon (validator: CryptoDungeon)