### PR TITLE
fix(ante): pass appCodec to HandlerOptions (v4.0.1 panics on every tx without this)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -672,6 +672,7 @@ func NewPassageApp(
 			WasmConfig:        wasmConfig,
 			TxCounterStoreKey: keys[wasm.StoreKey],
 			CircuitKeeper:     &app.CircuitKeeper,
+			Codec:             appCodec,
 		},
 	)
 


### PR DESCRIPTION
## Follow-up to #210 — v4.0.1 still bricks the tx layer without this one line

#210 fixed the InterfaceRegistry address codec (and ibctm + cosmwasm_1_3). But there's a **fourth** defect that only becomes reachable *once #210 is applied*, and without it v4.0.1 replaces "every tx rejected" with "every tx panics" — the chain stays dead after the swap.

### The bug
`app/app.go` builds `HandlerOptions{}` for the ante handler **without setting `Codec`**, so `passageante.NewBlockAccountDecorator(options.Codec)` receives a nil codec. `BlockAccountDecorator.AnteHandle` → `handleMessages` → `cdc.GetMsgV1Signers(msg)` then nil-pointer **panics on every non-simulate tx**.

On v4.0.0 this was masked because signer resolution failed earlier (missing InterfaceRegistry codec → `code 1`). After #210 fixes that codec, execution reaches the custom ante and crashes with `code 111222` `nil pointer dereference` in `x/auth/ante.SetUpContextDecorator` (recovery of the panic thrown in `app/ante.handleMessages`).

### The fix
One line — set the codec that `NewAnteHandler` already expects:
```go
CircuitKeeper:     &app.CircuitKeeper,
Codec:             appCodec,   // <-- added
```

### Verification (real mainnet state, by broadcast — not generate-only)
Forked current mainnet state, ran the released v4.0.0 binary → a bank send is rejected `code 1`. Swapped to a v4.0.1 build carrying #210 **plus this commit** → the same bank send returns `code 0` and is included in a block. We confirmed this with the reproducible static release binary (commit including this fix), not just a dev build.

⚠️ Generate-only, query, and even the migration dry-run all pass straight through this — it only surfaces when you actually broadcast a tx against real state. Recommend adding a broadcast smoke test to CI.

Please merge and re-cut the `v4.0.1` tag (the current tag `fd7bcad` is missing this). Reproducible binaries built from the fixed tree, if useful:
- amd64 `sha256 900a35b8742e8c0dfe23fdd10918594c0be27cf814cc262596dba0ac56fa6dff`
- arm64 `sha256 fcb5fe0b66d548e4a197fb2b7127ec35a791c705b91ba02367136bf146cf3b32`
